### PR TITLE
Refactored and some bug fixes

### DIFF
--- a/lib/meta-state.rb
+++ b/lib/meta-state.rb
@@ -71,9 +71,9 @@ module MetaState
         @void_state_module = Module.new do
           methods.each do |method|
             if NON_MESSAGES.include?(method)
-              define_method(method){}
+              define_method(method){|*args| }
             else
-              define_method(method) do
+              define_method(method) do |*args|
                 raise WrongStateError, "Message #{method} received in state #{current_state}"
               end
             end

--- a/lib/sockjs/session.rb
+++ b/lib/sockjs/session.rb
@@ -70,6 +70,12 @@ module SockJS
         close(1002,"Connection interrupted")
       end
 
+      def activate
+      end
+
+      def suspended
+      end
+
       def send(*messages)
         @outbox += messages
       end
@@ -235,7 +241,7 @@ module SockJS
 
     def run_user_app
       unless @received_messages.empty?
-        reset_heartbeat_timer
+        reset_heartbeat_timer #XXX Only one point which can set hearbeat while state is closed
 
         SockJS.debug "Executing user's SockJS app"
 

--- a/lib/sockjs/session.rb
+++ b/lib/sockjs/session.rb
@@ -74,12 +74,6 @@ module SockJS
         @outbox += messages
       end
 
-      def suspend
-      end
-
-      def activate
-      end
-
       def close(status = nil, message = nil)
         @close_status = status
         @close_message = message
@@ -413,6 +407,10 @@ module SockJS
     end
 
     def set_heartbeat_timer
+      if current_state == SockJS::Session::Closed
+        SockJS.debug "trying to setup heartbeat on closed session!"
+        return
+      end
       clear_timer(:disconnect)
       clear_timer(:alive)
       set_timer(:heartbeat, EM::PeriodicTimer, 25) do
@@ -422,7 +420,11 @@ module SockJS
 
     def reset_heartbeat_timer
       clear_timer(:heartbeat)
-      set_heartbeat_timer
+      if current_state == SockJS::Session::Closed
+        SockJS.debug "trying to setup heartbeat on closed session!"
+      else
+        set_heartbeat_timer
+      end
     end
 
     def set_disconnect_timer

--- a/lib/sockjs/transports/websocket.rb
+++ b/lib/sockjs/transports/websocket.rb
@@ -1,4 +1,7 @@
-# encoding: utf-8
+
+
+def activate
+end# encoding: utf-8
 
 require "forwardable"
 require "sockjs/faye"
@@ -61,8 +64,10 @@ module SockJS
         if not @options[:websocket]
           raise HttpError.new(404, "WebSockets Are Disabled")
         elsif request.env["HTTP_UPGRADE"].to_s.downcase != "websocket"
+          SockJS.debug("Worng headers! HTTP_UPGRADE = #{request.env["HTTP_UPGRADE"].to_s}")
           raise HttpError.new(400, 'Can "Upgrade" only to "WebSocket".')
         elsif not ["Upgrade", "keep-alive, Upgrade"].include?(request.env["HTTP_CONNECTION"])
+          SockJS.debug("Worng headers! HTTP_CONNECTION = #{request.env["HTTP_CONNECTION"].to_s}")
           raise HttpError.new(400, '"Connection" must be "Upgrade".')
         end
 

--- a/lib/sockjs/version.rb
+++ b/lib/sockjs/version.rb
@@ -7,7 +7,7 @@ module SockJS
   PROTOCOL_VERSION_STRING = PROTOCOL_VERSION.join(".")
 
   # Patch version of the gem.
-  PATCH_VERSION = [3]
+  PATCH_VERSION = [4]
 
   GEM_VERSION = (PROTOCOL_VERSION + PATCH_VERSION).join(".")
 end


### PR DESCRIPTION
I've refactored session and web socket transport. I've created suspended state. Also in suspended state messages are not send, but queued in outbox.

There are some bug fixes:
lib/meta-state.rb:77:in `block (3 levels) in build_void_state': wrong number of arguments (1 for 0) (ArgumentError)
and 
 Exception when sending heartbeat frame: #<MetaState::WrongStateError: Message send_heartbeat received in state SockJS::Session::Closed>
